### PR TITLE
Prevent Special Characters in the room name

### DIFF
--- a/bizhawk co-op.lua
+++ b/bizhawk co-op.lua
@@ -2,7 +2,7 @@ local guiClick = {}
 
 mainform = nil
 local text1, lblRooms, btnGetRooms, ddRooms, btnQuit, btnJoin, btnHost
-local txtUser, txtPass, lblUser, lblPass, ddRamCode, lblRamCode
+local tempUser, txtUser, txtPass, lblUser, lblPass, ddRamCode, lblRamCode
 local lblPort, txtPort
 config = {}
 
@@ -126,8 +126,15 @@ function prepareConnection()
 	else 
 		config.room = ''
 	end
+	
+	tempUser = forms.gettext(txtUser);
+	printOutput(tempUser)
+	if (tempUser:find("[%w]") == 1) then
+		config.user = tempUser
+	else 
+		printOutput("ERROR: Username may only consist of letters and numbers.")
+	end
 	config.ramcode = forms.gettext(ddRamCode)
-	config.user = forms.gettext(txtUser)
 	config.pass = forms.gettext(txtPass)
 	config.port = forms.gettext(txtPort)
 	config.hostname = forms.gettext(txtIP)


### PR DESCRIPTION
This PR adds form validation to the username field of the Lua script. If a user attempts to create or join a room with a non-alphanumeric character in their username, they receive an error in the Lua console informing them that the username must be made up of only letters or numbers. 

This script change has been tested with the creation of a room, joining a room, and used for a live multiworld to ensure that nothing else was broken by this modification.