### PR TITLE
Allow setting # of triforce pieces in oot.sav from Lua console 

### DIFF
--- a/bizhawk-co-op/helpers/oot.lua
+++ b/bizhawk-co-op/helpers/oot.lua
@@ -627,7 +627,7 @@ local Save_Context = Layout:create {
 	magic_meter_size = e( 0x13F4, Int_16 ),
 
 	-- ex: oot.sav.triforce_pieces = 0x01 - doesn't seem to work with decimal vals
-	triforce_pieces = e( 0xD4 + 0x1C * 0x48 + 0x10, Int_32)
+	triforce_pieces = e( 0xD4 + 0x1C * 0x48 + 0x10, Int_32),
 
 }
 

--- a/bizhawk-co-op/helpers/oot.lua
+++ b/bizhawk-co-op/helpers/oot.lua
@@ -626,6 +626,9 @@ local Save_Context = Layout:create {
 
 	magic_meter_size = e( 0x13F4, Int_16 ),
 
+	-- ex: oot.sav.triforce_pieces = 0x01 - doesn't seem to work with decimal vals
+	triforce_pieces = e( 0xD4 + 0x1C * 0x48 + 0x10, Int_32)
+
 }
 
 -- events:


### PR DESCRIPTION
ex. oot.sav.triforce_pieces = 0x##

Tested by Cubs

Had an incident recently where a player was desynced in scarce item pool and had 1 less triforce piece than everyone else, could not finish. This can hard-set the # of triforce pieces to correct things like that