### PR TITLE
Update BizHawk to 2.5, Prereqs to 2.4.8_1

### DIFF
--- a/bizhawk-co-op.ps1
+++ b/bizhawk-co-op.ps1
@@ -2,22 +2,22 @@
 
 $shell_app=new-object -com shell.application
 
-mkdir BizHawk-2.3
+mkdir BizHawk-2.5
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 #Download Bizhawk
-$url = "https://github.com/TASVideos/BizHawk/releases/download/2.3/BizHawk-2.3.zip"
-$filename = "bizHawk-2.3.zip"
+$url = "https://github.com/TASVideos/BizHawk/releases/download/2.5/BizHawk-2.5.0.zip"
+$filename = "bizHawk-2.5.zip"
 Invoke-WebRequest -Uri $url -OutFile $filename
 #Unzip
 $zip_file = $shell_app.namespace((Get-Location).Path + "\$filename")
-$destination = $shell_app.namespace((Get-Location).Path + "\BizHawk-2.3")
+$destination = $shell_app.namespace((Get-Location).Path + "\BizHawk-2.5")
 $destination.Copyhere($zip_file.items())
 Remove-Item $filename
 
 #Download prereq
-$url = "https://github.com/TASVideos/BizHawk-Prereqs/releases/download/2.1/bizhawk_prereqs_v2.1.zip"
+$url = "https://github.com/TASVideos/BizHawk-Prereqs/releases/download/2.4.8_1/bizhawk_prereqs_v2.4.8_1.zip"
 $filename = "bizprereq.zip"
 Invoke-WebRequest -Uri $url -OutFile $filename
 #unzip prereq
@@ -48,13 +48,13 @@ $destination.Copyhere($zip_file.items())
 Remove-Item $filename
 
 #Copy files into Bizhawk
-Move-Item -Path .\bizhawk-co-op-dev\* -Destination .\BizHawk-2.3\
+Move-Item -Path .\bizhawk-co-op-dev\* -Destination .\BizHawk-2.5\
 Remove-Item .\bizhawk-co-op-dev -Recurse
 
-Move-Item -Path .\luasocket\mime -Destination .\BizHawk-2.3\
-Move-Item -Path .\luasocket\socket -Destination .\BizHawk-2.3\
-Move-Item -Path .\luasocket\lua\* -Destination .\BizHawk-2.3\Lua\
-Move-Item -Path .\luasocket\lua5.1.dll -Destination .\BizHawk-2.3\dll\
+Move-Item -Path .\luasocket\mime -Destination .\BizHawk-2.5\
+Move-Item -Path .\luasocket\socket -Destination .\BizHawk-2.5\
+Move-Item -Path .\luasocket\lua\* -Destination .\BizHawk-2.5\Lua\
+Move-Item -Path .\luasocket\lua5.1.dll -Destination .\BizHawk-2.5\dll\
 Remove-Item .\luasocket -Recurse
 
 Start-Process .\bizhawk_prereqs.exe -Wait


### PR DESCRIPTION
BizHawk 2.3 has [issues with XBOX controllers](https://wiki.ootrandomizer.com/index.php?title=Bizhawk#XBOX_Controller_Troubleshooting). These are fixed by updating to BizHawk 2.5 and adjusting a setting. Having this version as the one installed by default instead of having to download it and ensure it the script gets configured properly would benefit users.

There has been some concern about versions other than 2.3 being problematic for MW, so I believe some people will want this version to be tested before this is merged. I'm pretty sure the issues that have cropped up were from mis-configuration, and a change in the default BizHawk settings that has [long since been mentioned during configuration now](https://wiki.ootrandomizer.com/index.php?title=Multiworld&diff=1933&oldid=1782), but I'm not against being thorough.

Note that this script has also not been tested by me yet either as I don't have a way to run it. I merely changed the URLs and version number references.

This version should be supported by Windows 7 SP1 and up (but not Windows 8 since 8.1 made it lose support early) the same as BizHawk 2.0 and prereqs 2.0 and newer.