### PR TITLE
Compatibility with version 3 of the OoTR co-op context

### DIFF
--- a/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
+++ b/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
@@ -35,11 +35,15 @@ local save_context = 0x11A5D0
 local internal_count_addr = save_context + 0x90
 
 -- check protocol version
-local script_protocol_version = 2
+local script_protocol_version_min = 2
+local script_protocol_version_max = 3
 local rom_protocol_version = mainmemory.read_u32_be(protocol_version_addr)
-if (rom_protocol_version ~= script_protocol_version) then
+if (rom_protocol_version < script_protocol_version_min) then
 	setmetatable(_G, old_global_metatable)
-	error("This ROM is not compatible with this version of the co-op script\nScript protocol version: "..script_protocol_version.."\nROM protocol version: "..rom_protocol_version)
+	error("This ROM is not compatible with this version of the co-op script\nMinimum script protocol version: "..script_protocol_version_min.."\nROM protocol version: "..rom_protocol_version)
+elseif (rom_protocol_version > script_protocol_version_max) then
+	setmetatable(_G, old_global_metatable)
+	error("This ROM is not compatible with this version of the co-op script\nMaximum script protocol version: "..script_protocol_version_max.."\nROM protocol version: "..rom_protocol_version)
 end
 
 -- get your player num


### PR DESCRIPTION
This changes the RAM controller for Ocarina of Time to accept version 3 of the co-op context, which is being added in TestRunnerSRL/OoT-Randomizer#1691. That version introduces a new field which may be set by a multiworld controller to change the behavior, but with that field left alone, all the existing fields are still at the same position and size with the same semantics, so only the version check had to be adjusted.