### PR TITLE
Compatibility with version 6 of the OoTR co-op context

### DIFF
--- a/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
+++ b/bizhawk-co-op/ramcontroller/Ocarina of Time.lua
@@ -36,7 +36,7 @@ local internal_count_addr = save_context + 0x90
 
 -- check protocol version
 local script_protocol_version_min = 2
-local script_protocol_version_max = 5
+local script_protocol_version_max = 6
 local rom_protocol_version = mainmemory.read_u32_be(protocol_version_addr)
 if (rom_protocol_version < script_protocol_version_min) then
 	setmetatable(_G, old_global_metatable)


### PR DESCRIPTION
For https://github.com/OoTRandomizer/OoT-Randomizer/pull/2079. The progressive items feature is not used by bizhawk-co-op, so no additional changes are necessary.